### PR TITLE
Add ARM64 build support

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,5 +1,5 @@
 FROM ubuntu:16.04
-# FROM arm=armhf/ubuntu:16.04
+# FROM arm=armhf/ubuntu:16.04 arm64=arm64v8/ubuntu:16.04
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
@@ -8,14 +8,15 @@ RUN apt-get update && \
     apt-get install -y gcc ca-certificates git wget curl vim less file && \
     rm -f /bin/sh && ln -s /bin/bash /bin/sh
 
-ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
+ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64 GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
-RUN wget -O - https://storage.googleapis.com/golang/go1.8.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go get github.com/rancher/trash && go get github.com/golang/lint/golint
+RUN wget -O - https://storage.googleapis.com/golang/go1.11.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
+    go get github.com/rancher/trash && go get golang.org/x/lint/golint
 
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
     DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
+    DOCKER_URL_arm64=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm64 \
     DOCKER_URL=DOCKER_URL_${ARCH}
 
 RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker


### PR DESCRIPTION
**Included**  
Add support for building loglevel for ARM64.

**Related issue**  
https://github.com/rancher/rancher/issues/16461

**Build Environment**  
The  ARM64 binary needs to be built in an ARM64 environment.