### PR TITLE
Added CI pipe for ARM arch

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -71,3 +71,41 @@ volumes:
   - name: docker
     host:
       path: /var/run/docker.sock
+
+---
+kind: pipeline
+name: arm
+
+platform:
+  os: linux
+  arch: arm
+
+steps:
+- name: build
+  pull: default
+  image: rancher/dapper:v0.4.1
+  commands:
+    - dapper ci
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+
+- name: github_binary_release
+  image: plugins/github-release
+  settings:
+    api_key:
+      from_secret: github_token
+    files:
+    - "dist/artifacts/*"
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock


### PR DESCRIPTION
Currently, Raspberry Pi 4 only has ARM support officially (Ubuntu ARM64 doesn't support RPi 4). Raspbian for RPi 4 will only have 32bit armhf support for long time. In order to support K3s cluster composed of  RPi4, we need to have binaries built for arm arch.

see https://github.com/rancher/rancher/issues/21243