### PR TITLE
Add s390x support

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -71,3 +71,43 @@ volumes:
   - name: docker
     host:
       path: /var/run/docker.sock
+---
+kind: pipeline
+name: s390x
+
+platform:
+  os: linux
+  arch: amd64
+
+node:
+  arch: s390x
+
+steps:
+  - name: build
+    pull: default
+    image: rancher/dapper:v0.5.8
+    commands:
+      - dapper ci
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+
+  - name: github_binary_release
+    image: rancher/drone-images:github-release-s390x
+    settings:
+      api_key:
+        from_secret: github_token
+      files:
+        - "dist/artifacts/*"
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        - refs/head/master
+        - refs/tags/*
+      event:
+        - tag
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,3 +1,6 @@
+FROM golang:1.16.8-alpine3.14 AS go
+RUN go get -u golang.org/x/lint/golint
+
 FROM ubuntu:16.04
 # FROM arm=armhf/ubuntu:16.04
 
@@ -8,18 +11,26 @@ RUN apt-get update && \
     apt-get install -y gcc ca-certificates git wget curl vim less file && \
     rm -f /bin/sh && ln -s /bin/bash /bin/sh
 
-ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64 GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
+ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64 GOLANG_ARCH_s390x=s390x GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
 RUN wget -O - https://storage.googleapis.com/golang/go1.9.7.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go get github.com/rancher/trash && go get github.com/golang/lint/golint
+    go get github.com/rancher/trash
+
+COPY --from=go /go/bin/golint /usr/bin
 
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
     DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
     DOCKER_URL_arm64=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm64 \
     DOCKER_URL=DOCKER_URL_${ARCH}
 
-RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
+RUN if [ "${ARCH}" == "s390x" ]; then \
+        curl -L https://download.docker.com/linux/static/stable/s390x/docker-18.06.3-ce.tgz | tar xzvf - && \
+        cp docker/docker /usr/bin/ && \
+        chmod +x /usr/bin/docker; \
+    else \
+        wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker; \
+    fi
 
 ENV DAPPER_ENV REPO TAG
 ENV DAPPER_SOURCE /go/src/github.com/rancher/loglevel


### PR DESCRIPTION
Download golint in another docker stage as it is not possible to install golint using go get in go 1.9 anymore.
I was getting the following error while installing golint:
```
go/src/golang.org/x/tools/internal/typeparams/normalize.go:66:9: undefined: types.NewInterfaceType
go/src/golang.org/x/tools/internal/typeparams/normalize.go:158:17: u.EmbeddedType undefined (type *types.Interface has no field or method EmbeddedType)
```
