### PR TITLE
Update Go to 1.22

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ platform:
 steps:
 - name: build
   pull: default
-  image: rancher/dapper:v0.4.1
+  image: rancher/dapper:v0.6.0
   commands:
     - dapper ci
   volumes:
@@ -45,7 +45,7 @@ platform:
 steps:
 - name: build
   pull: default
-  image: rancher/dapper:v0.4.1
+  image: rancher/dapper:v0.6.0
   commands:
     - dapper ci
   volumes:
@@ -72,43 +72,3 @@ volumes:
     host:
       path: /var/run/docker.sock
 
----
-kind: pipeline
-name: s390x
-
-platform:
-  os: linux
-  arch: amd64
-
-node:
-  arch: s390x
-
-steps:
-  - name: build
-    pull: default
-    image: rancher/dapper:v0.5.8
-    commands:
-      - dapper ci
-    volumes:
-      - name: docker
-        path: /var/run/docker.sock
-
-  - name: github_binary_release
-    image: rancher/drone-images:github-release-s390x
-    settings:
-      api_key:
-        from_secret: github_token
-      files:
-        - "dist/artifacts/*"
-    when:
-      instance:
-        - drone-publish.rancher.io
-      ref:
-        - refs/head/master
-        - refs/tags/*
-      event:
-        - tag
-volumes:
-  - name: docker
-    host:
-      path: /var/run/docker.sock

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,32 +1,10 @@
-FROM ubuntu:16.04
-# FROM arm=armhf/ubuntu:16.04
+FROM registry.suse.com/bci/golang:1.22
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 
-RUN apt-get update && \
-    apt-get install -y gcc ca-certificates git wget curl vim less file && \
-    rm -f /bin/sh && ln -s /bin/bash /bin/sh
-
-ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64 GOLANG_ARCH_s390x=s390x GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
-    GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
-
-RUN wget -O - https://storage.googleapis.com/golang/go1.17.5.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go get golang.org/x/lint/golint
-    
-
-ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
-    DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
-    DOCKER_URL_arm64=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm64 \
-    DOCKER_URL=DOCKER_URL_${ARCH}
-
-RUN if [ "${ARCH}" == "s390x" ]; then \
-        curl -L https://download.docker.com/linux/static/stable/s390x/docker-18.06.3-ce.tgz | tar xzvf - && \
-        cp docker/docker /usr/bin/ && \
-        chmod +x /usr/bin/docker; \
-    else \
-        wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker; \
-    fi
+RUN zypper refresh
+RUN go install golang.org/x/lint/golint@latest
 
 ENV DAPPER_ENV REPO TAG
 ENV DAPPER_SOURCE /go/src/github.com/rancher/loglevel

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module loglevel
 
-go 1.17
+go 1.22
 
 require github.com/urfave/cli v1.22.5
 


### PR DESCRIPTION
The main objective of this PR is to bump Go to 1.22 in order to fix possible CVEs in the Go's standard library and runtime (it helps silence dozens of false positive alerts).

It also does the bare minimum to allow the bump (without doing the transition from Drone to GHA - which must be done later):

- Bump `rancher/dapper` to `v0.6.0`.
- Remove `s390x` related steps from the pipeline.
- Simplify `Dockerfile.dapper` to use `registry.suse.com/bci/golang:1.22` as the base image.
  - Only install the minimum needed `golint` package (doesn't migrate to `golanci-lint`.